### PR TITLE
Update 08_ruby_challenges.markdown

### DIFF
--- a/1510/08_ruby_challenges.markdown
+++ b/1510/08_ruby_challenges.markdown
@@ -17,7 +17,8 @@
 
 * GitHub Repo: https://github.com/brantwellman/Turing-Swift-Lyrics-Counter
 * Pig Latin Repo:
-* Event Reporter Repo:
+* Event Reporter Repo: https://github.com/brantwellman/Turing-Event-Reporter
+* Mario: https://gist.github.com/brantwellman/0ef5ad1c0bf08c72cd5a
 
 #### Brenna Martenson
 


### PR DESCRIPTION
Brant - Add links to Mario and Event Reporter repos