### PR TITLE
adds link to Noah's blog/site

### DIFF
--- a/1608-b/2module/intermission_work/personal_site_html_css.yml
+++ b/1608-b/2module/intermission_work/personal_site_html_css.yml
@@ -42,8 +42,8 @@ submisssions:
     github repo link:
       url:
   Name: Noah Berman
-    github repo link:
-      url:
+    github repo link: https://github.com/bermannoah/nbdotorg_blog
+      url: http://blog.noahberman.org
   Name: Ryan Travitz
     github repo link: https://github.com/rtravitz/rtravitz.github.io
       url: https://rtravitz.github.io/


### PR DESCRIPTION
If it makes a difference: it's running on my personal domain but it just has dummy-text for all of the posts, so I didn't link to it from the 'live' site.